### PR TITLE
PIP-403 error handling and logging added

### DIFF
--- a/rna-seq-pipeline.wdl
+++ b/rna-seq-pipeline.wdl
@@ -290,6 +290,7 @@ workflow rna {
 
         output {
             File rnaQC = glob("*.json")[0]
+            File python_log = glob("rna_qc.log")[0]
         }
 
         runtime {

--- a/src/rna_qc.py
+++ b/src/rna_qc.py
@@ -178,6 +178,7 @@ def get_gene_type_counts(tr_to_gene_type_map, bampath):
     """
     bamfile = pysam.AlignmentFile(bampath, 'rb')
     reads_by_gene_type = {key: 0 for key in set(tr_to_gene_type_map.values())}
+    reads_by_gene_type.update({'transcript_id_not_found': 0})
     for read in bamfile.fetch(until_eof=True):
         if read.is_secondary or read.is_unmapped or read.is_qcfail or read.is_duplicate:
             continue
@@ -189,6 +190,7 @@ def get_gene_type_counts(tr_to_gene_type_map, bampath):
             except KeyError:
                 logger.exception('Transcript ID %s not found in mapping!',
                                  read.reference_name)
+                reads_by_gene_type['transcript_id_not_found'] += 1
     return reads_by_gene_type
 
 

--- a/src/rna_qc.py
+++ b/src/rna_qc.py
@@ -182,9 +182,13 @@ def get_gene_type_counts(tr_to_gene_type_map, bampath):
         if read.is_secondary or read.is_unmapped or read.is_qcfail or read.is_duplicate:
             continue
         else:
-            reference_name = read.reference_name
-            gene_type = tr_to_gene_type_map[reference_name]
-            reads_by_gene_type[gene_type] += 1
+            try:
+                reference_name = read.reference_name
+                gene_type = tr_to_gene_type_map[reference_name]
+                reads_by_gene_type[gene_type] += 1
+            except KeyError:
+                logger.exception('Transcript ID %s not found in mapping!',
+                                 read.reference_name)
     return reads_by_gene_type
 
 

--- a/test/test_workflow/PE_stranded_reference_md5.json
+++ b/test/test_workflow/PE_stranded_reference_md5.json
@@ -17,6 +17,6 @@
     "rep2PE_stranded_abundance.tsv" : "978043aa488549b864bdb1da1ef8e51b",
     "rep1PE_stranded_anno_number_of_genes_detected.json" : "0fe77b2bd349f7e3fe6cc84d1117f694",
     "rep2PE_stranded_anno_number_of_genes_detected.json" : "372623d436e5cf297e03bd6d3472ffd7",
-    "rep1qc.json" : "3f868f57d62913694e06be2e5e20249a",
-    "rep2qc.json" : "7637c3f7a2d7f1ddb813869fe2c043d8"
+    "rep1qc.json" : "52b4c5266918672b8d1b68d5076c3c02",
+    "rep2qc.json" : "df4ccf99aab7e9c03449b7dd443b57da"
 }

--- a/test/test_workflow/PE_unstranded_reference_md5.json
+++ b/test/test_workflow/PE_unstranded_reference_md5.json
@@ -5,5 +5,5 @@
     "rep1PE_unstranded_genome_all.bw" : "b74635ecc6935a33dd0c7c239d1717bd",
     "rep1PE_unstranded_abundance.tsv" : "2e319b57db723e97a1df81547854fed9",
     "rep1PE_unstranded_anno_number_of_genes_detected.json" : "63314a59af9d32626f3a36dc632fbff7",
-    "rep1qc.json" : "bd4693de3918fc67db5cf005b52be0c5"
+    "rep1qc.json" : "38e9d355e10110094a601a95c56226f2"
 }

--- a/test/test_workflow/SE_unstranded_reference_md5.json
+++ b/test/test_workflow/SE_unstranded_reference_md5.json
@@ -12,7 +12,7 @@
     "rep2SE_unstranded_abundance.tsv" : "1efd28ac45dc29b609a01342554d2a9f",
     "rep1SE_unstranded_anno_number_of_genes_detected.json" : "e5763e2407983d565c1a12b2d4f4f03b",
     "rep2SE_unstranded_anno_number_of_genes_detected.json" : "afddf3799f03f27be72f69f5c1fb40b2",
-    "rep1qc.json" : "46e640d5d670761ea8b0bfc47db1f10e",
-    "rep2qc.json" : "5e9cc78f2a0223dd09a880e8a0d1db62",
+    "rep1qc.json" : "304a158935325e2cd87ac01e663a3315",
+    "rep2qc.json" : "a156e94d66a01d6184b1d08e7ca69294",
     "rep1SE_unstranded_anno_rsem-rep2SE_unstranded_anno_rsem_mad_qc_metrics.json" : "d1585b513886921bf3c3e2af58726ea8"
 }


### PR DESCRIPTION
Small but important change. I was going back and forth on this and in the end decided that this should not result in the failure of pipeline run. The challenge in this decision is that it is kind of bad either way. It would be aggravating to have a long pipeline run fail because wrong .tsv (benign typo, forgotten spikes, etc.) or something like that. This could be an indication of a genuine error though (the user has a different annotation from the one they think they have, for example) and nobody ever reads logs before something actually borks, right?