### PR TITLE
Pip 424 bam to signal memory

### DIFF
--- a/src/bam_to_signals.py
+++ b/src/bam_to_signals.py
@@ -11,6 +11,7 @@ import argparse
 import logging
 import shlex
 import subprocess
+import sys
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -41,7 +42,8 @@ def main(args):
     except AssertionError:
         logger.exception('Building bedGraph had a problem, most likely out of memory.')
         raise
-        
+        sys.exit(1)
+
     if args.strandedness == 'stranded':
         call_bg_to_bw('Signal.UniqueMultiple.str1.out.bg', args.chrom_sizes,
                       args.bamroot + '_minusAll.bw')

--- a/src/bam_to_signals.py
+++ b/src/bam_to_signals.py
@@ -41,7 +41,6 @@ def main(args):
         assert star_return_code == 0
     except AssertionError:
         logger.exception('Building bedGraph had a problem, most likely out of memory.')
-        raise
         sys.exit(1)
 
     if args.strandedness == 'stranded':


### PR DESCRIPTION
If the signal track generation ran out of memory, the pipeline failed silently. Now the failure is apparent.