### PR TITLE
Pip 557 actor factory hotfix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
             pyenv global 3.5.2
             source ${BASH_ENV}
             test/test_workflow/test.sh rna-seq-pipeline.wdl test/test_workflow/SE_unstranded_input.json $TAG docker
-            python3 src/compare_md5.py --keys_to_inspect rna.rna_qc.rnaQC rna.rsem_quant.number_of_genes rna.mad_qc.madQCmetrics rna.mad_qc.madQCplot rna.kallisto.quants rna.align.genome_flagstat rna.align.anno_flagstat rna.bam_to_signals.all rna.bam_to_signals.unique --metadata_json SE_unstranded_input.metadata.json --reference_json test/test_workflow/SE_unstranded_reference_md5.json --outfile SE_unstranded_input.result.json
+            python3 src/compare_md5.py --keys_to_inspect rna.rna_qc.rnaQC rna.rsem_quant.number_of_genes rna.mad_qc.madQCmetrics rna.kallisto.quants rna.align.genome_flagstat rna.align.anno_flagstat rna.bam_to_signals.all rna.bam_to_signals.unique --metadata_json SE_unstranded_input.metadata.json --reference_json test/test_workflow/SE_unstranded_reference_md5.json --outfile SE_unstranded_input.result.json
             cat SE_unstranded_input.result.json
             python3 -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data['match_overall']))" < SE_unstranded_input.result.json
           no_output_timeout: 30m
@@ -128,7 +128,7 @@ jobs:
             pyenv global 3.5.2
             source ${BASH_ENV}
             test/test_workflow/test.sh rna-seq-pipeline.wdl test/test_workflow/PE_stranded_input.json $TAG docker
-            python3 src/compare_md5.py --keys_to_inspect rna.rna_qc.rnaQC rna.rsem_quant.number_of_genes rna.mad_qc.madQCmetrics rna.mad_qc.madQCplot rna.kallisto.quants rna.align.genome_flagstat rna.align.anno_flagstat rna.bam_to_signals.all rna.bam_to_signals.unique --metadata_json PE_stranded_input.metadata.json --reference_json test/test_workflow/PE_stranded_reference_md5.json --outfile PE_stranded_input.result.json
+            python3 src/compare_md5.py --keys_to_inspect rna.rna_qc.rnaQC rna.rsem_quant.number_of_genes rna.mad_qc.madQCmetrics rna.kallisto.quants rna.align.genome_flagstat rna.align.anno_flagstat rna.bam_to_signals.all rna.bam_to_signals.unique --metadata_json PE_stranded_input.metadata.json --reference_json test/test_workflow/PE_stranded_reference_md5.json --outfile PE_stranded_input.result.json
             cat PE_stranded_input.result.json
             python3 -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data['match_overall']))" < PE_stranded_input.result.json
           no_output_timeout: 30m
@@ -164,7 +164,7 @@ jobs:
             pyenv global 3.5.2
             source ${BASH_ENV}
             test/test_workflow/test.sh rna-seq-pipeline.wdl test/test_workflow/SE_unstranded_input.json $TAG singularity
-            python3 src/compare_md5.py --keys_to_inspect rna.rna_qc.rnaQC rna.rsem_quant.number_of_genes rna.mad_qc.madQCmetrics rna.mad_qc.madQCplot rna.kallisto.quants rna.align.genome_flagstat rna.align.anno_flagstat rna.bam_to_signals.all rna.bam_to_signals.unique --metadata_json SE_unstranded_input.metadata.json --reference_json test/test_workflow/SE_unstranded_reference_md5.json --outfile SE_unstranded_input.result.json
+            python3 src/compare_md5.py --keys_to_inspect rna.rna_qc.rnaQC rna.rsem_quant.number_of_genes rna.mad_qc.madQCmetrics rna.kallisto.quants rna.align.genome_flagstat rna.align.anno_flagstat rna.bam_to_signals.all rna.bam_to_signals.unique --metadata_json SE_unstranded_input.metadata.json --reference_json test/test_workflow/SE_unstranded_reference_md5.json --outfile SE_unstranded_input.result.json
             cat SE_unstranded_input.result.json
             python3 -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data['match_overall']))" < SE_unstranded_input.result.json
           no_output_timeout: 30m
@@ -182,7 +182,7 @@ jobs:
             pyenv global 3.5.2
             source ${BASH_ENV}
             test/test_workflow/test.sh rna-seq-pipeline.wdl test/test_workflow/PE_stranded_input.json $TAG singularity
-            python3 src/compare_md5.py --keys_to_inspect rna.rna_qc.rnaQC rna.rsem_quant.number_of_genes rna.mad_qc.madQCmetrics rna.mad_qc.madQCplot rna.kallisto.quants rna.align.genome_flagstat rna.align.anno_flagstat rna.bam_to_signals.all rna.bam_to_signals.unique --metadata_json PE_stranded_input.metadata.json --reference_json test/test_workflow/PE_stranded_reference_md5.json --outfile PE_stranded_input.result.json
+            python3 src/compare_md5.py --keys_to_inspect rna.rna_qc.rnaQC rna.rsem_quant.number_of_genes rna.mad_qc.madQCmetrics rna.kallisto.quants rna.align.genome_flagstat rna.align.anno_flagstat rna.bam_to_signals.all rna.bam_to_signals.unique --metadata_json PE_stranded_input.metadata.json --reference_json test/test_workflow/PE_stranded_reference_md5.json --outfile PE_stranded_input.result.json
             cat PE_stranded_input.result.json
             python3 -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data['match_overall']))" < PE_stranded_input.result.json
           no_output_timeout: 30m

--- a/backends/backend.conf
+++ b/backends/backend.conf
@@ -195,7 +195,7 @@ backend {
     }
 
     google {
-      actor-factory = "cromwell.backend.impl.jes.JesBackendLifecycleActorFactory"
+      actor-factory = "cromwell.backend.google.pipelines.v1alpha2.PipelinesApiLifecycleActorFactory"
       config {
         # Google project
         project = "your-project-name"

--- a/test/test_workflow/PE_stranded_reference_md5.json
+++ b/test/test_workflow/PE_stranded_reference_md5.json
@@ -11,7 +11,6 @@
     "rep2PE_stranded_genome_plusAll.bw" : "0f5c4d502a3560b942e7640ffda4019a",
     "rep2PE_stranded_genome_minusUniq.bw" : "82876a4e77641ba5af4b8b58396022e9",
     "rep2PE_stranded_genome_plusUniq.bw" : "a27151499caf7e7da096f864b3e178d0",
-    "rep1PE_stranded_anno_rsem-rep2PE_stranded_anno_rsem_mad_plot.png" : "1d30c776326377be24e68b056ce57405",
     "rep1PE_stranded_anno_rsem-rep2PE_stranded_anno_rsem_mad_qc_metrics.json" : "acc5dfbba14837082a9cc283d18a4b0c",
     "rep1PE_stranded_abundance.tsv" : "66620fd42cf8c91984565d478e0ced6a",
     "rep2PE_stranded_abundance.tsv" : "978043aa488549b864bdb1da1ef8e51b",

--- a/test/test_workflow/SE_unstranded_reference_md5.json
+++ b/test/test_workflow/SE_unstranded_reference_md5.json
@@ -7,7 +7,6 @@
     "rep1SE_unstranded_genome_flagstat.txt" : "ff3670d6acb285a140596641c86605cc",
     "rep2SE_unstranded_anno_flagstat.txt" : "9de0324a383cf4b5c68781b05b97e0f4",
     "rep2SE_unstranded_genome_flagstat.txt" : "7ff451f55a1d9036078bf9727d85f9d7",
-    "rep1SE_unstranded_anno_rsem-rep2SE_unstranded_anno_rsem_mad_plot.png" : "06a82fe46e07b88cfd58f64d01a1e6a9",
     "rep1SE_unstranded_abundance.tsv" : "07de1950ee4bf5fabd4daa92c0ccd423",
     "rep2SE_unstranded_abundance.tsv" : "1efd28ac45dc29b609a01342554d2a9f",
     "rep1SE_unstranded_anno_number_of_genes_detected.json" : "e5763e2407983d565c1a12b2d4f4f03b",


### PR DESCRIPTION
Main thing is to update the actor-factory that has been deprecated and causes problems. I have been meaning to disable testing the .pngs because all kind of R related and unrelated things break that and we are checking for the MAD metric numbers anyway and thought this is as good a time as any.