### PR TITLE
Pip 594 documentation hotfix

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,6 +12,10 @@ To check which Java version you already have, run:
 You are looking for 1.8 or higher. If the requirement is not fulfilled follow installation instructions for [mac](https://java.com/en/download/help/mac_install.xml) or
 [linux](http://openjdk.java.net/install/) or use your favorite installation method.
 
+## Cromwell
+
+Download wdl execution engine [Cromwell](https://github.com/broadinstitute/cromwell/releases/download/34/cromwell-34.jar)
+
 ## Docker
 
 Pipeline code is packaged and distributed in Docker containers, and thus Docker installation is needed. 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -7,6 +7,11 @@ This document contains more detailed information on the inputs, outputs and the 
 [Software](reference.md#software)  
 [Inputs](reference.md#inputs)  
 [Outputs](reference.md#outputs)
+[Genome Reference Files](reference.md#genome-files)
+
+## Genome Files
+
+Reference and index files can be downloaded from the [ENCODE Portal](https://www.encodeproject.org/search/?type=Reference&reference_type=index). These files are for human, and mouse will follow. Files that are needed are [GRCh38 STAR Index](https://www.encodeproject.org/files/ENCFF742NER/), [GRCh38 RSEM Index](https://www.encodeproject.org/references/ENCSR219BJA/), [GRCh38 Kallisto Index](https://www.encodeproject.org/references/ENCSR622RMG/) and [GRCh38 Chromosome sizes](https://www.encodeproject.org/files/GRCh38_EBV.chrom.sizes/).
 
 ## Software
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -125,7 +125,7 @@ Assume the `rna.bamroot` is `FOO`. Outputs from first replicate would be prefixe
 
 #### Note about resources:
 
-The hardware resources needed to run the pipeline depend the most on the sequencing depth, so it is hard to give definitive values that would be good for everyone. However for every pipeline run alignment is going to be the most memory intensive task, quantitation with RSEM is going to be computationally hardest, kallisto will require some non trivial amount of resources, and typically rest of the tasks are rather light both in cpu and memory use. Disk usage again depends on the sequencing depth, but `"local-disk 100 HDD"` is a good starting point for all the tasks. The following are recommendations that are a sensible starting point for further optimizations in a typical case (non cpu or memory related inputs omitted):
+The hardware resources needed to run the pipeline depend on the sequencing depth so it is hard to give definitive values that will be good for everyone. However, for every pipeline run, alignment is going to be the most memory-intensive task, quantitation with RSEM is going to be computationally hardest, kallisto will require some non-trivial amount of resources, and typically the rest of the tasks are rather light both in CPU and memory use. Disk usage again depends on the sequencing depth, but `"local-disk 100 HDD"` is a good starting point for all the tasks. The following are recommendations that are a sensible starting point for further optimizations in a typical case (non-CPU or memory related inputs omitted):
 
 ```
 {

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -7,6 +7,7 @@ This document contains more detailed information on the inputs, outputs and the 
 [Software](reference.md#software)  
 [Genome Reference Files](reference.md#genome-files)  
 [Inputs](reference.md#inputs)  
+[Resource Considerations](reference.md#note-about-resources)
 [Outputs](reference.md#outputs)
 
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -5,13 +5,10 @@ This document contains more detailed information on the inputs, outputs and the 
 # CONTENTS
 
 [Software](reference.md#software)  
+[Genome Reference Files](reference.md#genome-files)  
 [Inputs](reference.md#inputs)  
-[Outputs](reference.md#outputs)  
-[Genome Reference Files](reference.md#genome-files)
+[Outputs](reference.md#outputs)
 
-## Genome Files
-
-Reference and index files can be downloaded from the [ENCODE Portal](https://www.encodeproject.org/search/?type=Reference&reference_type=index). These files are for human, and mouse will follow. Files that are needed are [GRCh38 STAR Index](https://www.encodeproject.org/files/ENCFF742NER/), [GRCh38 RSEM Index](https://www.encodeproject.org/references/ENCSR219BJA/), [GRCh38 Kallisto Index](https://www.encodeproject.org/references/ENCSR622RMG/) and [GRCh38 Chromosome sizes](https://www.encodeproject.org/files/GRCh38_EBV.chrom.sizes/).
 
 ## Software
 
@@ -46,7 +43,11 @@ Samtools flagstats are calculated using [Samtools 1.9](https://github.com/samtoo
 ### bedGraphToBigWig and bedSort
 
 [bedGraphToBigWig kent source version 371](http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/bedGraphToBigWig) and [bedSort](http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/bedSort) (no version information available) are used in signal track generation. Source code is downloadable [here](http://hgdownload.soe.ucsc.edu/admin/exe/userApps.v371.src.tgz).
- 
+
+## Genome Files
+
+Reference and index files can be downloaded from the [ENCODE Portal](https://www.encodeproject.org/search/?type=Reference&reference_type=index). These files are for human, and mouse will follow. Files that are needed are [GRCh38 STAR Index](https://www.encodeproject.org/files/ENCFF742NER/), [GRCh38 RSEM Index](https://www.encodeproject.org/references/ENCSR219BJA/), [GRCh38 Kallisto Index](https://www.encodeproject.org/references/ENCSR622RMG/) and [GRCh38 Chromosome sizes](https://www.encodeproject.org/files/GRCh38_EBV.chrom.sizes/).
+
 ## Inputs
 
 A typical input file looks like this:
@@ -120,6 +121,23 @@ Assume the `rna.bamroot` is `FOO`. Outputs from first replicate would be prefixe
 * `rna.rsem_disk` As above, but for RSEM. 
 * `rna.kallisto_number_of_threads` How many threads are available for Kallisto quantification.
 * `rna.kallisto_ramGB` How many GBs of memory are available for Kallisto quantification.
+
+#### Note about resources:
+
+The hardware resources needed to run the pipeline depend the most on the sequencing depth, so it is hard to give definitive values that would be good for everyone. However for every pipeline run alignment is going to be the most memory intensive task, quantitation with RSEM is going to be computationally hardest, kallisto will require some non trivial amount of resources, and typically rest of the tasks are rather light both in cpu and memory use. Disk usage again depends on the sequencing depth, but `"local-disk 100 HDD"` is a good starting point for all the tasks. The following are recommendations that are a sensible starting point for further optimizations in a typical case (non cpu or memory related inputs omitted):
+
+```
+{
+    "rna.align_ncpus" : 8,
+    "rna.align_ramGB" : 32,
+    "rna.rsem_ncpus" : 8,
+    "rna.rsem_ramGB" : 32,
+    "rna.kallisto_number_of_threads" : 4,
+    "rna.kallisto_ramGB" : 8,
+    "rna.bam_to_signals_ncpus" : 2,
+    "rna.bam_to_signals_ramGB" : 4,
+}
+```
 
 #### Example:
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -7,7 +7,7 @@ This document contains more detailed information on the inputs, outputs and the 
 [Software](reference.md#software)  
 [Genome Reference Files](reference.md#genome-files)  
 [Inputs](reference.md#inputs)  
-[Resource Considerations](reference.md#note-about-resources)
+[Resource Considerations](reference.md#note-about-resources)  
 [Outputs](reference.md#outputs)
 
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,7 +6,7 @@ This document contains more detailed information on the inputs, outputs and the 
 
 [Software](reference.md#software)  
 [Inputs](reference.md#inputs)  
-[Outputs](reference.md#outputs)
+[Outputs](reference.md#outputs)  
 [Genome Reference Files](reference.md#genome-files)
 
 ## Genome Files


### PR DESCRIPTION
Reference files are not easier to find and resource ballpark values have been added.