### PR TITLE
#CROO added

### DIFF
--- a/rna-seq-pipeline.wdl
+++ b/rna-seq-pipeline.wdl
@@ -3,6 +3,7 @@
 
 #CAPER docker quay.io/encode-dcc/rna-seq-pipeline:v1.0
 #CAPER singularity docker://quay.io/encode-dcc/rna-seq-pipeline:v1.0
+#CROO out_def https://storage.googleapis.com/encode-pipeline-output-definition/bulkrna.output_definition.json
 
 workflow rna {
     # endedness: paired or single


### PR DESCRIPTION
Add #CROO output definition with a link to online version to output definition .json, so that the users do not need to define it on the command line.